### PR TITLE
Reorder and reprhase presentation of selectors in api.html

### DIFF
--- a/api.html
+++ b/api.html
@@ -97,33 +97,33 @@
                                             </tr>
                                             </thead>
                                             <tbody>
-                                            <tr>
+                                           <tr>
                                                 <th scope="row"><var>#allChildren</var></th>
-                                                <td>Return the receiver's children in the containment tree of the model, including the children's children recursively.</td>
+                                                <td>Returns the receiver's descendants (recursively) in the containment tree of the model.</td>
                                             </tr>
-                                            <tr>
-                                                <th scope="row"><var>#allChildrenTypes</var></th>
-                                                <td>Return all the possible children types of the receiver, including the possible type of the children's children recursively.</td>
+                                             <tr>
+                                                <th scope="row"><var>#children</var></th>
+                                                <td>Returns the receiver's direct descendant in the containment tree of the model (not recursive).</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#allParents</var></th>
-                                                <td>Return the receiver's parents in the containment tree of the model, including the parents' parents recursively.</td>
+                                                <td>Returns the receiver's ascendants (recursively) in the containment tree of the model.</td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row"><var>#parents</var></th>
+                                                <td>Returns the receiver's direct ascendants in the containment tree. This method (not recursive).</td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row"><var>#allChildrenTypes</var></th>
+                                                <td>Returns all the possible children types of the receiver, including the possible type of the children's children recursively.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#allParentTypes</var></th>
                                                 <td>Return all the possible parents types of the receiver, including the possible type of the parents' parents recursively.</td>
                                             </tr>
                                             <tr>
-                                                <th scope="row"><var>#children</var></th>
-                                                <td>Return the receiver's children in the containment tree of the model. This method is not recursive.</td>
-                                            </tr>
-                                            <tr>
                                                 <th scope="row"><var>#childrenTypes</var></th>
                                                 <td>Return the possible children types of the receiver. This method is not recursive.</td>
-                                            </tr>
-                                            <tr>
-                                                <th scope="row"><var>#parents</var></th>
-                                                <td>Return the receiver's parents in the containment tree of the model. This method is not recursive.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#parentTypes</var></th>

--- a/api.html
+++ b/api.html
@@ -12,7 +12,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Documentation of Moose Query, the query systeme of the Moose platform.">
-    <meta name="author" content="Cyril Ferlicot-Delbecque">
+    <meta name="author" content="Anquetil" >
 
     <!-- Favicon -->
     <link rel="apple-touch-icon" sizes="57x57" href="assets/favicon/apple-icon-57x57.png">
@@ -118,10 +118,6 @@
                                                 <td>Return the receiver's children in the containment tree of the model. This method is not recursive.</td>
                                             </tr>
                                             <tr>
-                                                <th scope="row"><var>#childrenSelectors</var></th>
-                                                <td>Return the selectors applicable to the receiver that can return some of the receiver's children.</td>
-                                            </tr>
-                                            <tr>
                                                 <th scope="row"><var>#childrenTypes</var></th>
                                                 <td>Return the possible children types of the receiver. This method is not recursive.</td>
                                             </tr>
@@ -130,12 +126,16 @@
                                                 <td>Return the receiver's parents in the containment tree of the model. This method is not recursive.</td>
                                             </tr>
                                             <tr>
-                                                <th scope="row"><var>#parentSelectors</var></th>
-                                                <td>Return the selectors applicable to the receiver that can return some of the receiver's parents.</td>
-                                            </tr>
-                                            <tr>
                                                 <th scope="row"><var>#parentTypes</var></th>
                                                 <td>Return the possible parents types of the receiver. This method is not recursive.</td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row"><var>#childrenSelectors</var></th>
+                                                <td>(meta-selector) Returns the selectors, understood by the receiver, that can return some or all of its children in the containment tree.</td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row"><var>#parentSelectors</var></th>
+                                                <td>(meta-selector) Returns the selectors, understood by the receiver, that can return some or all of its parents in the containment tree.</td>
                                             </tr>
                                             </tbody>
                                         </table>

--- a/api.html
+++ b/api.html
@@ -99,35 +99,35 @@
                                             <tbody>
                                            <tr>
                                                 <th scope="row"><var>#allChildren</var></th>
-                                                <td>Returns the receiver's descendants (recursively) in the containment tree of the model.</td>
+                                                <td>Returns the receiver's descendants (recursively) in the containment tree.</td>
                                             </tr>
                                              <tr>
                                                 <th scope="row"><var>#children</var></th>
-                                                <td>Returns the receiver's direct descendant in the containment tree of the model (not recursive).</td>
+                                                <td>Returns the receiver's direct descendants (not recursive) in the containment tree.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#allParents</var></th>
-                                                <td>Returns the receiver's ascendants (recursively) in the containment tree of the model.</td>
+                                                <td>Returns the receiver's ascendants (recursively) in the containment tree.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#parents</var></th>
-                                                <td>Returns the receiver's direct ascendants in the containment tree. This method (not recursive).</td>
+                                                <td>Returns the receiver's direct ascendants (not recursive) in the containment tree.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#allChildrenTypes</var></th>
-                                                <td>Returns all the possible children types of the receiver, including the possible type of the children's children recursively.</td>
-                                            </tr>
-                                            <tr>
-                                                <th scope="row"><var>#allParentTypes</var></th>
-                                                <td>Return all the possible parents types of the receiver, including the possible type of the parents' parents recursively.</td>
+                                                <td>Returns all possible classes of the receiver's descendants recursively.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#childrenTypes</var></th>
-                                                <td>Return the possible children types of the receiver. This method is not recursive.</td>
+                                                <td>Returns all possible classes of the receiver's direct descendants (not recursive).</td>
+                                             <tr>
+                                                <th scope="row"><var>#allParentTypes</var></th>
+                                                <td>Returns all possible types of the receiver's ascendant recursively.</td>
                                             </tr>
+                                           </tr>
                                             <tr>
                                                 <th scope="row"><var>#parentTypes</var></th>
-                                                <td>Return the possible parents types of the receiver. This method is not recursive.</td>
+                                                <td>Returns all possible types of the receiver's direct ascendants (not recursive).</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#childrenSelectors</var></th>

--- a/api.html
+++ b/api.html
@@ -155,13 +155,13 @@
                                             <tbody>
                                             <tr>
                                                 <th scope="row"><var>#atScope:</var></th>
-                                                <td>Famix class defining the scope of the query</td>
-                                                <td>Return the entities of the parameter's kind up in the containment tree of the model compared to the receiver.</td>
+                                                <td>A Famix class</td>
+                                                <td>Returns the ascendants of the receiver in the containment tree that are instances of the Famix class in parameter.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#toScope:</var></th>
-                                                <td>Famix class defining the scope of the query</td>
-                                                <td>Return the entities of the parameter's kind down in the containment tree of the model compared to the receiver.</td>
+                                                <td>A Famix class</td>
+                                                <td>Returns the descendants of the receiver in the containment tree that are instances of the Famix class in parameter.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#withScope:</var></th>

--- a/api.html
+++ b/api.html
@@ -158,30 +158,30 @@
                                                 <td>A Famix class</td>
                                                 <td>Returns the ascendants of the receiver in the containment tree that are instances of the Famix class in parameter.</td>
                                             </tr>
-                                            <tr>
+                                           <tr>
+                                                <th scope="row"><var>#allAtScope:</var></th>
+                                                <td>A Famix class</td>
+                                                <td>Returns the exaustive list of ascendants of the receiver in the containment tree that are instances of the Famix class in parameter (it will not stop at the first encountered entity of the right kind).</td>
+                                            </tr>
+                                             <tr>
                                                 <th scope="row"><var>#toScope:</var></th>
                                                 <td>A Famix class</td>
                                                 <td>Returns the descendants of the receiver in the containment tree that are instances of the Famix class in parameter.</td>
                                             </tr>
                                             <tr>
+                                                <th scope="row"><var>#allToScope:</var></th>
+                                                <td>A Famix class</td>
+                                                <td>Returns the exaustive list of descendants of the receiver in the containment tree that are instances of the Famix class in parameter (it will not stop at the first encountered entity of the right kind).</td>
+                                            </tr>
+                                            <tr>
                                                 <th scope="row"><var>#withScope:</var></th>
-                                                <td>Famix class</td>
+                                                <td>A Famix class</td>
                                                 <td>Returns the descendants and ascendants of the receiver in the containment tree that are instances of the Famix class in parameter.</td>
                                             </tr>
                                             <tr>
-                                                <th scope="row"><var>#allAtScope:</var></th>
-                                                <td>Famix class defining the scope of the query</td>
-                                                <td>Return all the entities at this given famix class scope that are up in the containment tree of the meta-model on multiple levels (it will not stop at the first encountered entity of the right kind).</td>
-                                            </tr>
-                                            <tr>
-                                                <th scope="row"><var>#allToScope:</var></th>
-                                                <td>Famix class defining the scope of the query</td>
-                                                <td>Return all the entities at this given famix class scope that are down in the containment tree of the meta-model on multiple levels (it will not stop at the first encountered entity of the right kind).</td>
-                                            </tr>
-                                            <tr>
                                                 <th scope="row"><var>#allWithScope:</var></th>
-                                                <td>Famix class defining the scope of the query</td>
-                                                <td>Return all the entities at this given famix class scope that are both up and down in the containment tree of the meta-model on multiple levels (it will not stop at the first encountered entity of the right kind).</td>
+                                                <td>A Famix class</td>
+                                                <td>Returns the descendants and ascendants of the receiver in the containment tree that are instances of the Famix class in parameter (it will not stop at the first encountered entity of the right kind).</td>
                                             </tr>
                                             </tbody>
                                         </table>

--- a/api.html
+++ b/api.html
@@ -165,8 +165,8 @@
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#withScope:</var></th>
-                                                <td>Famix class defining the scope of the query</td>
-                                                <td>Return the entities of the parameter's kind up and down in the containment tree of the model compared to the receiver.</td>
+                                                <td>Famix class</td>
+                                                <td>Returns the descendants and ascendants of the receiver in the containment tree that are instances of the Famix class in parameter.</td>
                                             </tr>
                                             <tr>
                                                 <th scope="row"><var>#allAtScope:</var></th>


### PR DESCRIPTION
Tried to make the explanation a bit shorter and clearer.

The difference between #allToScope: and #toScope:  is not entirely clear to me (and thus not clear either in the explanation